### PR TITLE
Add Google Tag Manager

### DIFF
--- a/components/LayoutLanding.js
+++ b/components/LayoutLanding.js
@@ -51,6 +51,17 @@ export const LandingLayout = (props) => {
           description,
           title,
         })}
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-VJZB8M2VYD"></script>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+
+                gtag('config', 'G-VJZB8M2VYD');`,
+          }}
+        />
       </Head>
 
       <LandingNav landingNav={header} />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 import { useRouter } from "next/router";
-import Script from "next/script";
 import Head from "next/head";
 import Link from "next/link";
 import { PrismicProvider } from "@prismicio/react";
@@ -43,16 +42,15 @@ export default function App({ Component, pageProps }) {
           rel="stylesheet"
         ></link>
 
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-VJZB8M2VYD"></script>
         <script
           dangerouslySetInnerHTML={{
             __html: `
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', '${gtag.GA_TRACKING_ID}', {
-        page_path: window.location.pathname,
-        });
-        `,
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+
+                gtag('config', 'G-VJZB8M2VYD');`,
           }}
         />
       </Head>
@@ -61,11 +59,6 @@ export default function App({ Component, pageProps }) {
         internalLinkComponent={internalLinkComponent}
       >
         <PrismicPreview repositoryName={repositoryName}>
-          <Script
-            strategy="afterInteractive"
-            src={`https://www.googletagmanager.com/gtag/js?id=${gtag.GA_TRACKING_ID}`}
-          />
-
           <ThemeProvider theme={Theme}>
             <GlobalStyle theme={Theme} />
             <Component {...pageProps} />


### PR DESCRIPTION
Se agrega nueva etiqueta Google Tag a todas las paginas para el seguimiento avanzado de campañas mediante Google Analytics.

<!-- Google tag (gtag.js) -->
<script async src="https://www.googletagmanager.com/gtag/js?id=G-VJZB8M2VYD"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());

  gtag('config', 'G-VJZB8M2VYD');
</script>